### PR TITLE
Update pyproject.toml to allow python3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License"
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 [tool.setuptools.packages.find]
 where = ["src"]
 


### PR DESCRIPTION
I confirmed that this is working on Python 3.11. Our team is now limited to using 3.11 and cannot use 3.12